### PR TITLE
Remove instructions for building the TAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,18 +60,13 @@ lunch hikey-userdebug
 ```
 
 ### 3.6. Download the Linaro toolchain
-The Linux kernel and Optee trusted apps are built using the Linaro gcc
-toolchain.  Use this helper script to download this for you:
+The Linux kernel is built using the Linaro gcc toolchain.  Use this
+helper script to download this for you:
 ```bash
 $ ./optee/get_toolchain.sh
 ```
 
-### 3.7. Build the userspace libraries and trusted apps:
-```bash
-$ ./optee/build_ta.sh hikey optee/android_optee_examples.cfg
-```
-
-### 3.8. Build the Linux kernel
+### 3.7. Build the Linux kernel
 There is also a helper script to build the Linux kernel.  Android
 typically uses pre-built kernels, so it is necessary to build this
 manually.
@@ -79,7 +74,7 @@ manually.
 $ ./optee/build_kernel.sh
 ```
 
-### 3.9. Run the rest of the android build, For an 8GB board, use:
+### 3.8. Run the rest of the android build, For an 8GB board, use:
 ```bash
 make -j32
 ```


### PR DESCRIPTION
The latest code supports building the trusted apps (TAs) as part of
the Android build, so it is not necessary to perform this as a
separate step.
