### PR TITLE
Apply TI patches from Linaro Git server

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -197,6 +197,18 @@ if [ "$dbg" = true ]; then
 	done
 fi
 
+## TI Git server has moved from http://git.ti.com/ to
+## http://git.ti.com/cgit/. This broke the TI patches.
+## As a workaround the same patches can be pulled from
+## Linaro Gerrit server. The ti.patch file patches the
+## android-patchsets repository to include this workaround.
+## Changes taken from 
+## https://android-git.linaro.org/android-patchsets.git/commit/?id=3f15d1669d9d19cd66dbe75ba4af8f6463028dfa
+  
+cd android-patchsets
+git apply ../ti.patch
+cd -
+
 for i in ${PATCHSETS}; do
 	echo ""
 	echo ""

--- a/ti.patch
+++ b/ti.patch
@@ -1,0 +1,24 @@
+diff --git a/P-RLCR-PATCHSET b/P-RLCR-PATCHSET
+index 0cf2fda..36ce3d2 100755
+--- a/P-RLCR-PATCHSET
++++ b/P-RLCR-PATCHSET
+@@ -52,7 +52,8 @@ cherrypick build/make af2e1f84870525c64e6071ded0903c721e43a232
+ ## ueventd: Add dynamic kernel module loading
+ ## cherrypick system/core 9963847419f41c76ca008cf0c09e986c79f04e4c
+ ## http://git.ti.com/android/platform-system-core/commit/949450945115165cf76f47c69b3f107a4db022f1
+-curl_am http://git.ti.com/android/platform-system-core/commit/949450945115165cf76f47c69b3f107a4db022f1?format=patch system/core
++## https://android-review.linaro.org/c/platform/system/core/+/21063
++apply --linaro system/core 21063/1
+ 
+ ## revert change of "Make libdrm recovery_available" from master branch
+ revert external/libdrm d9aac04d6cd8fb78ad600fe4d252b94877ba39bf
+@@ -69,7 +70,8 @@ apply --linaro external/drm_hwcomposer 20694/1
+ 
+ ## temp: compatibility_matrices: added 4.19 kernel support
+ ## http://git.ti.com/android/platform-hardware-interfaces/commit/4b03e692d337eafd0b1254bd30fa235f103409a2
+-curl_am http://git.ti.com/android/platform-hardware-interfaces/commit/4b03e692d337eafd0b1254bd30fa235f103409a2?format=patch hardware/interfaces
++## https://android-review.linaro.org/c/platform/hardware/interfaces/+/21064
++apply --linaro --local hardware/interfaces --remote platform/hardware/interfaces 21064/1
+ 
+ if [ -d external/u-boot ]; then
+ ## Patch from AOSP master for mkimage


### PR DESCRIPTION
Some patches from TI are causing sync to fail in the patch stage. This PR fixes that.